### PR TITLE
Encapsulate GUI initialization in main

### DIFF
--- a/calculator_gui.py
+++ b/calculator_gui.py
@@ -1,13 +1,10 @@
 import tkinter as tk
 
-# Create the main window
-root = tk.Tk()
-root.title("Calculator")
-
-# Create the display area
-display_var = tk.StringVar()
-display = tk.Entry(root, textvariable=display_var, width=35, borderwidth=5, justify="right", state="readonly")
-display.grid(row=0, column=0, columnspan=4, padx=10, pady=10)
+# Global references to the Tk widgets.  They are initialised inside ``main`` so
+# that importing this module does not try to create any GUI elements.
+root = None
+display_var = None
+display = None
 
 # --- Button Click Functionality ---
 def button_click(item):
@@ -230,39 +227,56 @@ def calculate_result(): # This is the Tkinter callback
     
     display.config(state="readonly")
 
+def main():
+    """Launch the calculator GUI."""
+    global root, display_var, display
 
-# Define button texts and their positions/commands
-buttons = [
-    ('7', 1, 0, button_click), ('8', 1, 1, button_click), ('9', 1, 2, button_click), ('/', 1, 3, button_click),
-    ('4', 2, 0, button_click), ('5', 2, 1, button_click), ('6', 2, 2, button_click), ('*', 2, 3, button_click),
-    ('1', 3, 0, button_click), ('2', 3, 1, button_click), ('3', 3, 2, button_click), ('-', 3, 3, button_click),
-    ('0', 4, 0, button_click), ('.', 4, 1, button_click), ('C', 4, 2, clear_display), ('+', 4, 3, button_click),
-    ('=', 5, 0, calculate_result, 4)  # Text, row, col, command, columnspan (optional)
-]
+    # Create the main window
+    root = tk.Tk()
+    root.title("Calculator")
 
-# Create and place buttons in the grid
-for button_info in buttons:
-    text = button_info[0]
-    row = button_info[1]
-    col = button_info[2]
-    command_func = button_info[3]
-    
-    # Determine if columnspan is specified
-    col_span = button_info[4] if len(button_info) == 5 else 1
-    
-    if text == 'C' or text == '=': # Specific commands for C and =
-        btn = tk.Button(root, text=text, padx=20, pady=20, command=command_func)
-    else: # For digits and operators, pass the text to button_click
-        btn = tk.Button(root, text=text, padx=20, pady=20, command=lambda t=text: command_func(t))
-        
-    btn.grid(row=row, column=col, columnspan=col_span, sticky="nsew")
+    # Create the display area
+    display_var = tk.StringVar()
+    display = tk.Entry(root, textvariable=display_var, width=35, borderwidth=5,
+                       justify="right", state="readonly")
+    display.grid(row=0, column=0, columnspan=4, padx=10, pady=10)
 
-# Configure column and row weights for responsiveness
-for i in range(4):
-    root.grid_columnconfigure(i, weight=1)
-for i in range(1, 6): # Rows 1 to 5 (where buttons are)
-    root.grid_rowconfigure(i, weight=1)
+    # Define button texts and their positions/commands
+    buttons = [
+        ('7', 1, 0, button_click), ('8', 1, 1, button_click), ('9', 1, 2, button_click), ('/', 1, 3, button_click),
+        ('4', 2, 0, button_click), ('5', 2, 1, button_click), ('6', 2, 2, button_click), ('*', 2, 3, button_click),
+        ('1', 3, 0, button_click), ('2', 3, 1, button_click), ('3', 3, 2, button_click), ('-', 3, 3, button_click),
+        ('0', 4, 0, button_click), ('.', 4, 1, button_click), ('C', 4, 2, clear_display), ('+', 4, 3, button_click),
+        ('=', 5, 0, calculate_result, 4)  # Text, row, col, command, columnspan (optional)
+    ]
+
+    # Create and place buttons in the grid
+    for button_info in buttons:
+        text = button_info[0]
+        row = button_info[1]
+        col = button_info[2]
+        command_func = button_info[3]
+
+        # Determine if columnspan is specified
+        col_span = button_info[4] if len(button_info) == 5 else 1
+
+        if text in ('C', '='):
+            btn = tk.Button(root, text=text, padx=20, pady=20, command=command_func)
+        else:
+            btn = tk.Button(root, text=text, padx=20, pady=20,
+                             command=lambda t=text: command_func(t))
+
+        btn.grid(row=row, column=col, columnspan=col_span, sticky="nsew")
+
+    # Configure column and row weights for responsiveness
+    for i in range(4):
+        root.grid_columnconfigure(i, weight=1)
+    for i in range(1, 6):  # Rows 1 to 5 (where buttons are)
+        root.grid_rowconfigure(i, weight=1)
+
+    # Start the Tkinter event loop
+    root.mainloop()
 
 
-# Start the Tkinter event loop
-root.mainloop()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create a `main()` function to house all Tkinter setup
- guard Tkinter startup behind `if __name__ == "__main__"`
- keep calculator logic functions importable without launching a window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68432597ab00833297a0fa7aecdf465c