### PR TITLE
Refactor calculator GUI creation

### DIFF
--- a/calculator_gui.py
+++ b/calculator_gui.py
@@ -1,268 +1,177 @@
 import tkinter as tk
 
-# Create the main window
-root = tk.Tk()
-root.title("Calculator")
-
-# Create the display area
-display_var = tk.StringVar()
-display = tk.Entry(root, textvariable=display_var, width=35, borderwidth=5, justify="right", state="readonly")
-display.grid(row=0, column=0, columnspan=4, padx=10, pady=10)
-
-# --- Button Click Functionality ---
-def button_click(item):
-    current_text = display_var.get()
-    display.config(state="normal")
-
-    operators = ['+', '-', '*', '/']
-
-    if item in "0123456789":
-        display_var.set(current_text + item)
-    elif item == ".":
-        # Find the start of the current number
-        last_op_index = -1
-        for op in operators:
-            try:
-                last_op_index = max(last_op_index, current_text.rindex(op))
-            except ValueError:
-                pass # Operator not found
-        
-        current_number = current_text[last_op_index+1:]
-        if "." not in current_number:
-            display_var.set(current_text + item)
-    elif item in operators:
-        if current_text: # If display is not empty
-            if current_text[-1] in operators: # Last char is an operator
-                display_var.set(current_text[:-1] + item) # Replace last operator
-            else:
-                display_var.set(current_text + item) # Append operator
-        # else: # If display is empty, could prepend '0' or do nothing
-            # display_var.set("0" + item) # Optional: start with 0 if operator is first
-    
-    display.config(state="readonly")
-
-def clear_display():
-    display.config(state="normal")
-    display_var.set("")
-    display.config(state="readonly")
-
-# --- Calculation Logic (Refactored for Testability) ---
+# --- 计算逻辑（为了便于测试的重构） ---
 
 def parse_expression(expression_string: str) -> list:
-    """
-    Parses an arithmetic expression string into a list of numbers (float) and operators (str).
-    Handles leading signs and negative numbers after operators.
-    Raises ValueError for malformed expressions.
-    """
+    """将算术表达式字符串解析为数字和运算符的列表。"""
     if not expression_string:
         return []
-    
+
     components = []
     current_num = ""
-    
-    for i, char in enumerate(expression_string):
+
+    for char in expression_string:
         if char.isdigit() or char == '.':
             current_num += char
         elif char in ['+', '-', '*', '/']:
-            if current_num: # Current number is complete, add it
+            if current_num:
                 components.append(float(current_num))
                 current_num = ""
-            # Handling for operators:
-            # 1. Leading sign for the very first number (e.g., "-5", "+3")
             elif not components and (char == '-' or char == '+'):
-                current_num += char # Start accumulating the signed number
+                current_num += char
                 continue
-            # 2. Operator at the beginning without a preceding number (e.g. *5 or /5) - error
-            elif not components: 
+            elif not components:
                 raise ValueError("Expression starts with an operator without a preceding number")
-            # 3. Operator after another operator (e.g., "5*+2" or "5--2")
             elif components and isinstance(components[-1], str):
-                if char == '-' and components[-1] in ['*', '/','+','-']: # Allow "5*-2" or "5+-2" or "5--2"
-                    current_num += char # This '-' is part of the next number
+                if char == '-' and components[-1] in ['*', '/', '+', '-']:
+                    current_num += char
                     continue
-                else: # "5*+2" or "5++2"
+                else:
                     raise ValueError("Consecutive operators not forming a negative number")
-            
-            components.append(char) # Add the operator
+            components.append(char)
         else:
             raise ValueError(f"Invalid character in expression: {char}")
 
-    if current_num: # Append the last number
+    if current_num:
         components.append(float(current_num))
-        
-    # Post-parsing to merge operator and negative sign if applicable. E.g. [5.0, '*', '-', 2.0] -> [5.0, '*', -2.0]
-    # This was part of the original logic, slightly adjusted for the new parsing flow.
-    # The new parsing flow for char == '-' when components[-1] is an operator and current_num is empty
-    # already handles cases like "5*-2" by making current_num = "-", then current_num = "-2".
-    # This explicit post-parsing consolidation might be redundant or simplified.
-    # For now, let's assume the new parsing handles it. If tests fail, revisit.
-    # The previous logic was:
-    # i = 0
-    # while i < len(components) -1:
-    #     if isinstance(components[i], str) and components[i] in ['*', '/','+'] and \
-    #        isinstance(components[i+1], str) and components[i+1] == '-':
-    #         if i+2 < len(components) and isinstance(components[i+2], float):
-    #             components[i+2] *= -1
-    #             components.pop(i+1) # remove the '-' sign
-    #         else: # e.g. "5*-"
-    #             raise ValueError("Operator followed by hanging minus")
-    #     i+=1
-            
+
     return components
 
+
 def _perform_core_calculation(components: list):
-    """
-    Performs the calculation based on a list of numbers and operators.
-    Follows operator precedence (*/ before +-).
-    Raises ValueError for format issues or ZeroDivisionError.
-    Returns the final numerical result.
-    """
+    """按照运算符优先级执行计算。"""
     if not components:
         raise ValueError("Empty components list for calculation")
 
-    # Handle expressions that are just a single number, possibly signed.
     if len(components) == 1 and isinstance(components[0], float):
         return components[0]
-    # This case might be hit if parse_expression produced something like ['-', 5.0] for "-5"
-    # which the current parse_expression tries to avoid by making it [-5.0] directly.
     if len(components) == 2 and components[0] == '-' and isinstance(components[1], float):
         return -components[1]
 
-
-    # Pass 1: Multiplication and Division
     i = 0
     while i < len(components):
         op = components[i]
-        if op == '*':
+        if op in {'*', '/'}:
             if i == 0 or i == len(components) - 1 or not isinstance(components[i-1], float) or not isinstance(components[i+1], float):
-                raise ValueError("Invalid multiplication format")
-            result = components[i-1] * components[i+1]
-            components = components[:i-1] + [result] + components[i+2:]
-            i = 0  # Restart scan
-            continue
-        elif op == '/':
-            if i == 0 or i == len(components) - 1 or not isinstance(components[i-1], float) or not isinstance(components[i+1], float):
-                raise ValueError("Invalid division format")
-            if components[i+1] == 0:
+                raise ValueError(f"Invalid {'multiplication' if op=='*' else 'division'} format")
+            if op == '/' and components[i+1] == 0:
                 raise ZeroDivisionError("Division by zero")
-            result = components[i-1] / components[i+1]
+            result = components[i-1] * components[i+1] if op == '*' else components[i-1] / components[i+1]
             components = components[:i-1] + [result] + components[i+2:]
-            i = 0  # Restart scan
+            i = 0
             continue
         i += 1
 
-    # Pass 2: Addition and Subtraction
     i = 0
     while i < len(components):
         op = components[i]
-        if op == '+':
+        if op in {'+', '-'}:
             if i == 0 or i == len(components) - 1 or not isinstance(components[i-1], float) or not isinstance(components[i+1], float):
-                raise ValueError("Invalid addition format")
-            result = components[i-1] + components[i+1]
+                raise ValueError(f"Invalid {'addition' if op=='+' else 'subtraction'} format")
+            result = components[i-1] + components[i+1] if op == '+' else components[i-1] - components[i+1]
             components = components[:i-1] + [result] + components[i+2:]
-            i = 0  # Restart scan
-            continue
-        elif op == '-': # Note: parse_expression should handle leading negatives to form numbers like -5.0
-            if i == 0 or i == len(components) - 1 or not isinstance(components[i-1], float) or not isinstance(components[i+1], float):
-                 # This can happen if it's the start of the list e.g. [-5.0, '+', 2.0] and we are at '-'
-                 # The current loop structure assumes operator is at components[i]
-                 # A list like [-5.0, '+', 2.0] should be handled by '+' correctly
-                 # A list like [5.0, '-', 2.0] is the standard case.
-                 # If components was like ['-', 5.0, '+', 2.0] (which parse_expression avoids), this would be an issue.
-                raise ValueError("Invalid subtraction format")
-            result = components[i-1] - components[i+1]
-            components = components[:i-1] + [result] + components[i+2:]
-            i = 0  # Restart scan
+            i = 0
             continue
         i += 1
-    
+
     if len(components) == 1 and isinstance(components[0], float):
         return components[0]
-    else:
-        # This implies a malformed expression not caught earlier or an issue in calculation logic
-        raise ValueError("Expression could not be reduced to a single result")
+    raise ValueError("Expression could not be reduced to a single result")
+
 
 def _evaluate_expression_string(expression_string: str):
-    """
-    High-level function to parse and calculate an expression string.
-    Returns a numerical result or an error message string.
-    """
+    """解析并计算表达式字符串的高级函数。"""
     if not expression_string:
-        return "Error: Empty Expression" # Or handle as appropriate (e.g., return 0 or None)
+        return "Error: Empty Expression"
 
     try:
         components = parse_expression(expression_string)
-        if not components: # e.g. if expression_string was just "   " or some other non-parseable input
-             # parse_expression itself might raise error for truly invalid chars.
-             # This handles cases where parse_expression returns empty list for benign non-expressions.
-            return "Error: Invalid Expression" 
-            
-        # If parse_expression returns a single number (e.g. "5" -> [5.0]),
-        # _perform_core_calculation will handle it.
-        # If components list is like ['-', 5.0] (which current parser avoids),
-        # _perform_core_calculation handles it too.
-
+        if not components:
+            return "Error: Invalid Expression"
         final_result = _perform_core_calculation(components)
         return final_result
-    except ValueError as e: # Catch errors from parse_expression or _perform_core_calculation
+    except ValueError as e:
         return f"Error: {str(e)}"
     except ZeroDivisionError:
         return "Error: Division by zero"
-    except Exception as e: # Catch any other unexpected errors
-        # It's good to log the actual exception e here for debugging
+    except Exception:
         return "Error: Calculation Failed"
 
 
-def calculate_result(): # This is the Tkinter callback
-    display.config(state="normal")
-    expression = display_var.get()
-    
-    eval_result = _evaluate_expression_string(expression)
+# --- 图形界面代码 -----------------------------------------------------------
 
-    if isinstance(eval_result, (int, float)):
-        # Format result: int if possible, else float
-        if eval_result == int(eval_result):
-            display_var.set(str(int(eval_result)))
+def run_calculator():
+    root = tk.Tk()
+    root.title("Calculator")
+
+    display_var = tk.StringVar()
+    display = tk.Entry(root, textvariable=display_var, width=35, borderwidth=5, justify="right", state="readonly")
+    display.grid(row=0, column=0, columnspan=4, padx=10, pady=10)
+
+    def button_click(item):
+        current_text = display_var.get()
+        display.config(state="normal")
+        operators = ['+', '-', '*', '/']
+        if item in "0123456789":
+            display_var.set(current_text + item)
+        elif item == ".":
+            last_op_index = -1
+            for op in operators:
+                try:
+                    last_op_index = max(last_op_index, current_text.rindex(op))
+                except ValueError:
+                    pass
+            current_number = current_text[last_op_index+1:]
+            if "." not in current_number:
+                display_var.set(current_text + item)
+        elif item in operators:
+            if current_text:
+                if current_text[-1] in operators:
+                    display_var.set(current_text[:-1] + item)
+                else:
+                    display_var.set(current_text + item)
+        display.config(state="readonly")
+
+    def clear_display():
+        display.config(state="normal")
+        display_var.set("")
+        display.config(state="readonly")
+
+    def calculate_result():
+        display.config(state="normal")
+        expression = display_var.get()
+        eval_result = _evaluate_expression_string(expression)
+        if isinstance(eval_result, (int, float)):
+            if eval_result == int(eval_result):
+                display_var.set(str(int(eval_result)))
+            else:
+                display_var.set(str(round(eval_result, 10)))
         else:
-            display_var.set(str(round(eval_result, 10))) # round to avoid long floating point issues
-    else: # It's an error string
-        display_var.set(eval_result)
-    
-    display.config(state="readonly")
+            display_var.set(eval_result)
+        display.config(state="readonly")
+
+    buttons = [
+        ('7', 1, 0, button_click), ('8', 1, 1, button_click), ('9', 1, 2, button_click), ('/', 1, 3, button_click),
+        ('4', 2, 0, button_click), ('5', 2, 1, button_click), ('6', 2, 2, button_click), ('*', 2, 3, button_click),
+        ('1', 3, 0, button_click), ('2', 3, 1, button_click), ('3', 3, 2, button_click), ('-', 3, 3, button_click),
+        ('0', 4, 0, button_click), ('.', 4, 1, button_click), ('C', 4, 2, clear_display), ('+', 4, 3, button_click),
+        ('=', 5, 0, calculate_result, 4)
+    ]
+
+    for info in buttons:
+        text, row, col, cmd = info[:4]
+        col_span = info[4] if len(info) == 5 else 1
+        action = cmd if text in {'C', '='} else lambda t=text: cmd(t)
+        btn = tk.Button(root, text=text, padx=20, pady=20, command=action)
+        btn.grid(row=row, column=col, columnspan=col_span, sticky="nsew")
+
+    for i in range(4):
+        root.grid_columnconfigure(i, weight=1)
+    for i in range(1, 6):
+        root.grid_rowconfigure(i, weight=1)
+
+    root.mainloop()
 
 
-# Define button texts and their positions/commands
-buttons = [
-    ('7', 1, 0, button_click), ('8', 1, 1, button_click), ('9', 1, 2, button_click), ('/', 1, 3, button_click),
-    ('4', 2, 0, button_click), ('5', 2, 1, button_click), ('6', 2, 2, button_click), ('*', 2, 3, button_click),
-    ('1', 3, 0, button_click), ('2', 3, 1, button_click), ('3', 3, 2, button_click), ('-', 3, 3, button_click),
-    ('0', 4, 0, button_click), ('.', 4, 1, button_click), ('C', 4, 2, clear_display), ('+', 4, 3, button_click),
-    ('=', 5, 0, calculate_result, 4)  # Text, row, col, command, columnspan (optional)
-]
-
-# Create and place buttons in the grid
-for button_info in buttons:
-    text = button_info[0]
-    row = button_info[1]
-    col = button_info[2]
-    command_func = button_info[3]
-    
-    # Determine if columnspan is specified
-    col_span = button_info[4] if len(button_info) == 5 else 1
-    
-    if text == 'C' or text == '=': # Specific commands for C and =
-        btn = tk.Button(root, text=text, padx=20, pady=20, command=command_func)
-    else: # For digits and operators, pass the text to button_click
-        btn = tk.Button(root, text=text, padx=20, pady=20, command=lambda t=text: command_func(t))
-        
-    btn.grid(row=row, column=col, columnspan=col_span, sticky="nsew")
-
-# Configure column and row weights for responsiveness
-for i in range(4):
-    root.grid_columnconfigure(i, weight=1)
-for i in range(1, 6): # Rows 1 to 5 (where buttons are)
-    root.grid_rowconfigure(i, weight=1)
-
-
-# Start the Tkinter event loop
-root.mainloop()
+if __name__ == "__main__":
+    run_calculator()

--- a/test_calculator_logic.py
+++ b/test_calculator_logic.py
@@ -3,7 +3,7 @@ from calculator_gui import _evaluate_expression_string, parse_expression
 
 class TestCalculatorLogic(unittest.TestCase):
 
-    # --- Tests for parse_expression ---
+    # --- parse_expression 的测试 ---
     def test_parse_valid_expressions(self):
         self.assertEqual(parse_expression("2+3"), [2.0, '+', 3.0])
         self.assertEqual(parse_expression("2.5*4"), [2.5, '*', 4.0])
@@ -12,7 +12,7 @@ class TestCalculatorLogic(unittest.TestCase):
         self.assertEqual(parse_expression("10+2.5-3*4/2"), [10.0, '+', 2.5, '-', 3.0, '*', 4.0, '/', 2.0])
         self.assertEqual(parse_expression("3"), [3.0])
         self.assertEqual(parse_expression("-3.14"), [-3.14])
-        self.assertEqual(parse_expression("+3.14"), [3.14]) # parse_expression turns +3.14 into 3.14
+        self.assertEqual(parse_expression("+3.14"), [3.14]) # parse_expression 会把 +3.14 解析为 3.14
         self.assertEqual(parse_expression("5+-2"), [5.0, '+', -2.0])
         self.assertEqual(parse_expression("5--2"), [5.0, '-', -2.0])
 
@@ -23,15 +23,15 @@ class TestCalculatorLogic(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Consecutive operators not forming a negative number"):
             parse_expression("2++3")
         with self.assertRaisesRegex(ValueError, "Consecutive operators not forming a negative number"):
-            parse_expression("2+*3") # This should be caught by "Consecutive operators"
+            parse_expression("2+*3") # 这个情况应当被 "连续运算符" 检测到
         with self.assertRaisesRegex(ValueError, "could not convert string to float: '-'"):
-            parse_expression("5*-") # current_num becomes "-", then float("-") is attempted at the end.
+            parse_expression("5*-") # current_num 变成 "-"，最终尝试 float("-") 时失败
 
         with self.assertRaisesRegex(ValueError, "Invalid character in expression: a"):
             parse_expression("2+3a")
-        self.assertEqual(parse_expression(""), []) # Empty string
+        self.assertEqual(parse_expression(""), []) # 空字符串
 
-    # --- Tests for _evaluate_expression_string ---
+    # --- _evaluate_expression_string 的测试 ---
     def test_basic_operations(self):
         self.assertEqual(_evaluate_expression_string("2+3"), 5)
         self.assertEqual(_evaluate_expression_string("5-3"), 2)
@@ -45,19 +45,19 @@ class TestCalculatorLogic(unittest.TestCase):
     def test_operator_precedence(self):
         self.assertEqual(_evaluate_expression_string("2+3*4"), 14)
         self.assertEqual(_evaluate_expression_string("10-4/2"), 8)
-        self.assertEqual(_evaluate_expression_string("2*3+4/2"), 8) # 6 + 2 = 8
-        self.assertEqual(_evaluate_expression_string("10/2*5"), 25) # 5 * 5 = 25 (left-to-right for same precedence)
+        self.assertEqual(_evaluate_expression_string("2*3+4/2"), 8) # 结果 6 + 2 = 8
+        self.assertEqual(_evaluate_expression_string("10/2*5"), 25) # 同等优先级从左到右计算，5 * 5 = 25
         self.assertEqual(_evaluate_expression_string("10+2-3*4/2+5"), 11) # 10+2-6+5 = 12-6+5 = 6+5 = 11
 
     def test_division_by_zero(self):
         self.assertEqual(_evaluate_expression_string("5/0"), "Error: Division by zero")
         self.assertEqual(_evaluate_expression_string("2+3*4/0"), "Error: Division by zero")
-        self.assertEqual(_evaluate_expression_string("10-0/0"), "Error: Division by zero") # 0/0 is also div by zero
+        self.assertEqual(_evaluate_expression_string("10-0/0"), "Error: Division by zero") # 0/0 也是除以零
 
     def test_edge_cases_evaluate(self):
         self.assertEqual(_evaluate_expression_string("5"), 5)
         self.assertEqual(_evaluate_expression_string("-5"), -5)
-        self.assertEqual(_evaluate_expression_string("+5"), 5) # parser makes [+5.0] into [5.0]
+        self.assertEqual(_evaluate_expression_string("+5"), 5) # 解析器会把 [+5.0] 转成 [5.0]
         self.assertEqual(_evaluate_expression_string("-2+3"), 1)
         self.assertEqual(_evaluate_expression_string("2+-3"), -1)
         self.assertEqual(_evaluate_expression_string("2*-3"), -6)
@@ -68,25 +68,25 @@ class TestCalculatorLogic(unittest.TestCase):
         self.assertEqual(_evaluate_expression_string(""), "Error: Empty Expression")
 
     def test_invalid_inputs_to_evaluate(self):
-        # These errors are caught by parse_expression and propagated by _evaluate_expression_string
+        # 这些错误由 parse_expression 检测并由 _evaluate_expression_string 传播
         self.assertEqual(_evaluate_expression_string("*2+3"), "Error: Expression starts with an operator without a preceding number")
         self.assertEqual(_evaluate_expression_string("2++3"), "Error: Consecutive operators not forming a negative number")
         self.assertEqual(_evaluate_expression_string("2+*3"), "Error: Consecutive operators not forming a negative number")
-        # For "5*-", parse_expression fails with float("-"). _evaluate_expression_string returns "Error: could not convert string to float: '-'"
+        # 对于 "5*-"，parse_expression 在执行 float("-") 时失败，_evaluate_expression_string 会返回 "Error: could not convert string to float: '-'"
         self.assertEqual(_evaluate_expression_string("5*-"), "Error: could not convert string to float: '-'")
-        self.assertEqual(_evaluate_expression_string("5*"), "Error: Invalid multiplication format") # Caught by _perform_core_calculation
-        self.assertEqual(_evaluate_expression_string("5+"), "Error: Invalid addition format")   # Caught by _perform_core_calculation
+        self.assertEqual(_evaluate_expression_string("5*"), "Error: Invalid multiplication format") # 被 _perform_core_calculation 捕获
+        self.assertEqual(_evaluate_expression_string("5+"), "Error: Invalid addition format")   # 被 _perform_core_calculation 捕获
         self.assertEqual(_evaluate_expression_string("/5"), "Error: Expression starts with an operator without a preceding number")
         self.assertEqual(_evaluate_expression_string("5/"), "Error: Invalid division format")
         self.assertEqual(_evaluate_expression_string("abc"), "Error: Invalid character in expression: a")
         self.assertEqual(_evaluate_expression_string("3+a*2"), "Error: Invalid character in expression: a")
         
-        # Test expressions with trailing or leading decimal points that are valid numbers
-        self.assertEqual(parse_expression("3+2."), [3.0, '+', 2.0]) # Parser test
-        self.assertEqual(_evaluate_expression_string("3+2."), 5.0)   # Evaluator test
+        # 测试尾部或前导小数点的合法数字表达式
+        self.assertEqual(parse_expression("3+2."), [3.0, '+', 2.0]) # 解析测试
+        self.assertEqual(_evaluate_expression_string("3+2."), 5.0)   # 计算测试
         
-        self.assertEqual(parse_expression(".2+3"), [0.2, '+', 3.0]) # Parser test
-        self.assertEqual(_evaluate_expression_string(".2+3"), 3.2)    # Evaluator test
+        self.assertEqual(parse_expression(".2+3"), [0.2, '+', 3.0]) # 解析测试
+        self.assertEqual(_evaluate_expression_string(".2+3"), 3.2)    # 计算测试
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- refactor calculator_gui so GUI is only created when run as a script
- expose `run_calculator()` to start the GUI
- translate comments to Chinese

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684328025244833282c176c701cc578e